### PR TITLE
fix: truncation of big number hex

### DIFF
--- a/number-conversions/hex.js
+++ b/number-conversions/hex.js
@@ -93,9 +93,7 @@ function hexToAscii(hex) {
  * for example (0xff -> [1,1,1,1,1,1,1,1]) 11111111
  */
 function hexToBinArray(hex) {
-  return parseInt(hex, 16)
-    .toString(2)
-    .split('');
+  return hexToBin(hex).split('')
 }
 
 /**

--- a/number-conversions/hex.js
+++ b/number-conversions/hex.js
@@ -89,19 +89,19 @@ function hexToAscii(hex) {
 }
 
 /**
- * Converts hex strings into binary, so that they can be passed into merkle-proof.code
- * for example (0xff -> [1,1,1,1,1,1,1,1]) 11111111
- */
-function hexToBinArray(hex) {
-  return hexToBin(hex).split('')
-}
-
-/**
  * The hexToBinary library was giving some funny values with 'undefined' elements within the binary string.
  * Using convertBase seems to be working nicely.
  */
 function hexToBin(hex) {
   return convertBase(strip0x(hex), 16, 2);
+}
+
+/**
+ * Converts hex strings into binary, so that they can be passed into merkle-proof.code
+ * for example (0xff -> [1,1,1,1,1,1,1,1]) 11111111
+ */
+function hexToBinArray(hex) {
+  return hexToBin(hex).split('');
 }
 
 /**


### PR DESCRIPTION
### Description

`hexToBinArray` uses `parseInt` to convert a hex string into a `number` before converting to `binary`. For large hex strings the `number` representation is truncated resulting in trailing zeroes in the `binary array` representation. 

Alternative fixes would be to use, the now native, `BigInt` parsing. For simplicity this solution uses the existing `hexToBin`, although this is a slower conversion than `BigInt`

### QA Instructions

```
// Demo of parsing issue.
let  hex = 'ce6d7b5282bd9a3661ae061feed1dbda4e52ab073b1f9285be6e155d9c38d4ec'
> parseInt(hex,16).toString(2)
'1100111001101101011110110101001010000010101111011001100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'

> BigInt('0x'+hex).toString(2)
'1100111001101101011110110101001010000010101111011001101000110110011000011010111000000110000111111110111011010001110110111101101001001110010100101010101100000111001110110001111110010010100001011011111001101110000101010101110110011100001110001101010011101100'

// Before this PR
> hexToBinArray('hex').join('')
'1100111001101101011110110101001010000010101111011001100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'

 // After this PR
> hex.hexToBinArray('hex').join('')
'1100111001101101011110110101001010000010101111011001101000110110011000011010111000000110000111111110111011010001110110111101101001001110010100101010101100000111001110110001111110010010100001011011111001101110000101010101110110011100001110001101010011101100'
```

### Checklist

<!-- Go over the checklist, and put an `x` in all the boxes when you confirm they've been done. -->

- [x] I have reviewed the code changes myself
- [x] I have removed unused code (e.g., `console.logs`, commented out blocks, etc.)
